### PR TITLE
notify only once

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,16 +12,46 @@ import Footer from "./components/Footer/Footer.jsx";
 import { Volume2, VolumeX } from "lucide-react";
 import "./App.css";
 
-function App() {
-  const [showGate, setShowGate] = useState(true);
-  const [showIntro, setShowIntro] = useState(false);
+const setNotifCookie = (name, value, days=365) => {
+  const expires = new Date(Date.now() + days * 864e5).toUTCString();
+  document.cookie = `${name}=${value}; expires=${expires}; path=/; SameSite=Lax`;
+};
 
+const getNotifCookie = (name) => {
+  return document.cookie.split("; ").find((row) => row.startsWith(name + "="))?.split("=")[1];
+};
+
+function App() {
+
+  
+  const [showGate, setShowGate] = useState(() => {
+    const permission = Notification.permission;
+    const interacted = getNotifCookie("push_interacted") === "true";
+    
+    //show gate if permission is default (meaning it is not "granted" or "denied") and user has not interacted yet
+    return permission === "default" && !interacted;
+  });
+  
+  const [showIntro, setShowIntro] = useState(false);
+  
   const [muted, setMuted] = useState(
     () => localStorage.getItem("bg-muted") === "true"
   );
-
+  
   const introAudioRef = useRef(new Audio("/audio/intro.mp3"));
   const bgAudioRef = useRef(new Audio("/audio/bg-audio.mp3"));
+  
+  useEffect(() => {
+    //if subscribe gate is skipped (because permission/cookie exists), start intro automatically
+    //NOTE: NO USER INTERACTION SO BROWSER BLOCKS AUTOPLAY WITH SOUND ON RELOAD/NEXT VISITS
+    if (!showGate && !showIntro) {
+      introAudioRef.current.currentTime = 0;
+      introAudioRef.current.volume = 0.5;
+      introAudioRef.current.play().catch(err => {});
+
+      setShowIntro(true);
+    }
+  }, []);
 
   /* Cleanup intro audio */
   useEffect(() => {
@@ -82,6 +112,8 @@ function App() {
       {showGate && (
         <SubscribeGate
           onContinue={() => {
+            setNotifCookie("push_interacted", "true");
+
             introAudioRef.current.currentTime = 0;
             introAudioRef.current.volume = 0.5;
             introAudioRef.current.play().catch(() => {});


### PR DESCRIPTION
-use of cookie to record interaction with subscribe gate. it is now only rendered only if default browser behavior and no resp. cookie is found (first visit/ resetting website permissions).

-since there is no prior user interaction on refresh/ next visits, browser blocks autoplay on sound for the website intro on these. website bgm still plays though. possible fix is to implement a "START" button for the website or mute/unmute button like in the actual website for intro aswell. (neither included here)