### PR TITLE
Admin dashboard final v3

### DIFF
--- a/frontend/src/pages/SuperAdminDashboard.jsx
+++ b/frontend/src/pages/SuperAdminDashboard.jsx
@@ -156,8 +156,8 @@ export default function SuperAdminDashboard() {
 
       setAlerts([{ message: successMessage + ` for Team: ${editedTeam.team_name}`, severity: 0 }]);
 
-      //re-fetch both teams and rooms after a save so availability stays fresh
-      await Promise.all([fetchTeams(), fetchRooms()]);
+      //re-fetch teams, users and rooms after a save so data stays fresh for excel download
+      await Promise.all([fetchTeams(), fetchUsers(), fetchRooms()]);
     } catch (err) {
       setAlerts([{ message: err.message, severity: 2 }]);
     }

--- a/frontend/src/utils/Admin/TeamDetailsModal.jsx
+++ b/frontend/src/utils/Admin/TeamDetailsModal.jsx
@@ -88,7 +88,7 @@ function PanelDropdown({ value, onChange, allRooms }) {
                     : "transparent";
                 }}
               >
-                Room {room.room_number}
+                Panel {room.room_number}
               </div>
             );
           })}


### PR DESCRIPTION
- Tested the functioning of admin dashboard for the final time. Everything works as intended.
- **Issue fixed:** Currently, on updating team details, the team object gets updated instantly but changes in users are only reflected in the frontend after the page is refreshed. This means that if for a team, the room number was updated, it would register in the frontend incase of the team object and so the excel download for team data would be upto date. However this would not be the case for User data. If after editing team details, page is not refreshed, the downloaded excel of user data would contain the previous content, which is incorrect. **The Solution:** re-fetch user data when team details are saved. team and room data were already being re-fetched in current implementation, so their behavior was correct.